### PR TITLE
fix buildRest throw exp when params is empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pico-common",
-    "version": "0.11.3",
+    "version": "0.11.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -17,9 +17,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
-            "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
+            "version": "3.6.7",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.7.tgz",
+            "integrity": "sha512-4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==",
             "dev": true,
             "requires": {
                 "commander": "~2.20.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pico-common",
-    "version": "0.11.4",
+    "version": "0.11.5",
     "description": "pico common tools",
     "main": "bin/pico.js",
     "scripts": {
@@ -30,6 +30,6 @@
     },
     "homepage": "https://github.com/ldarren/pico-common",
     "devDependencies": {
-        "uglify-js": "^3.6.3"
+        "uglify-js": "^3.6.5"
     }
 }

--- a/src/plugins/str.js
+++ b/src/plugins/str.js
@@ -147,7 +147,7 @@ define('pico/str', function(){
 				}
 			}
 			if (!codes) return api
-			var url = buildRest('', codes[1], 0, params, '/', true)
+			var url = buildRest('', codes[1], 0, params || {}, '/', true)
 			if (!url) return false
 			var c
 			for (i=2; (c = codes[i]); i++){

--- a/tests/pico.str.js
+++ b/tests/pico.str.js
@@ -106,6 +106,13 @@ parallel('pico/str', function(){
 		var url=pstr.buildRest(route, build, {ver:1.9})
 		cb(null, route ===  url)
 	})
+	this.test('ensure builder rest can handle empty params gracefully',function(cb){
+		var route = 'http://localhost:3000/api/%ver/cal'
+		pstr.compileRest(route, build)
+		// no exception here
+		var url=pstr.buildRest(route, build)
+		cb(null, !url)
+	})
 	this.test('ensure codec encode string "{"data":123}" and decode to the same', function(cb){
 		var
 			data = JSON.stringify({data:123}),


### PR DESCRIPTION
when pass empty params to buildRest, it throws exception instead of url === false